### PR TITLE
modify release name validation and change branch name on tap ios ci

### DIFF
--- a/.github/workflows/cocoa-pods.yml
+++ b/.github/workflows/cocoa-pods.yml
@@ -26,14 +26,15 @@ jobs:
           RELEASE_VERSION="${{ github.event.release.tag_name }}"
           echo "Release Name: $RELEASE_NAME"
           echo "Release Version: $RELEASE_VERSION"
-
-          if [[ "$RELEASE_NAME" =~ TapOnPhoneSDK-iOS ]]; then
+      
+          if [[ "$RELEASE_NAME" =~ ^TapOnPhoneSDK-iOS\ \-\ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Release matches the pattern."
             echo "MATCHED=true" >> $GITHUB_ENV
           else
             echo "Release does not match the pattern."
             echo "MATCHED=false" >> $GITHUB_ENV
           fi
+    
 
       - name: Exit if release name doesn't match the pattern
         if: env.MATCHED == 'false'
@@ -62,6 +63,14 @@ jobs:
             exit 1
           fi
 
+      - name: Get commit author info
+        id: author_info
+        run: |
+          AUTHOR_NAME=$(git log -1 --pretty=format:'%an')
+          AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
+          echo "author_name=$AUTHOR_NAME" >> $GITHUB_OUTPUT
+          echo "author_email=$AUTHOR_EMAIL" >> $GITHUB_OUTPUT
+
       - name: Create Podspec file
         run: |
           XCFRAMEWORK_ROOT="./sources"
@@ -75,7 +84,7 @@ jobs:
             s.description      = 'Receive payments with iPhone using NFC'
             s.homepage         = 'https://github.com/getzoop/zoop-package-public'
             s.license          = { :type => 'MIT', :file => 'LICENSE' }
-            s.author           = { 'Wellington Nascente Hirsch' => 'wellington.hirsch@ifood.com.br' }
+            s.author           = { '${{ steps.author_info.outputs.author_name }}' => '${{ steps.author_info.outputs.author_email }}' }
             s.source           = { :git => 'https://github.com/getzoop/zoop-package-public.git', :tag => '${{ github.event.release.tag_name }}' }
             s.source_files     = '${XCFRAMEWORK_ROOT}/**/*.h'
             s.public_header_files = '${XCFRAMEWORK_ROOT}/**/*.h'
@@ -126,7 +135,7 @@ jobs:
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           
-          BRANCH_NAME="${{ github.event.release.name }}/${{ github.event.release.tag_name }}"
+          BRANCH_NAME="release-${{ github.event.release.tag_name }}"
           echo "Branch: $BRANCH_NAME"
           
           git checkout -b "$BRANCH_NAME" || git checkout "$BRANCH_NAME"


### PR DESCRIPTION
### **User description**
Modificar a validação de nome para trigar o CI do Tap iOS e muda o nome da versão


___

### **PR Type**
Enhancement


___

### **Description**
- Melhoria na validação do nome de release

- Adição de informações do autor do commit

- Alteração no formato do nome da branch

- Regex mais preciso para validação de versão


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cocoa-pods.yml</strong><dd><code>Melhorias no workflow de publicação do CocoaPods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cocoa-pods.yml

<li>Adicionado regex mais preciso para validação do nome de release <br>(^TapOnPhoneSDK-iOS\ \-\ [0-9]+\.[0-9]+\.[0-9]+$)<br> <li> Incluído passo para obter informações do autor do commit (nome e <br>email)<br> <li> Alterado o formato do nome da branch para "release-{tag}" em vez de <br>"{nome_release}/{tag}"<br> <li> Substituído autor fixo no podspec pelo autor dinâmico do commit


</details>


  </td>
  <td><a href="https://github.com/getzoop/zoop-package-public/pull/9/files#diff-7249470b1169bbcc06e08b589ea756b192cf783bee6bcdb5defeab9acf3e5a8c">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>