### PR TITLE
fix path and license

### DIFF
--- a/.github/workflows/cocoa-pods.yml
+++ b/.github/workflows/cocoa-pods.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Create Podspec file
         run: |
-          XCFRAMEWORK_ROOT="./sources"
+          XCFRAMEWORK_ROOT="sources"
           PODSPEC_CONTENT="
           Pod::Spec.new do |s|
             s.name             = '${SDK_NAME}'
@@ -82,7 +82,7 @@ jobs:
             s.summary          = 'Tap on phone SDK for iOS'
             s.description      = 'Receive payments with iPhone using NFC'
             s.homepage         = 'https://github.com/getzoop/zoop-package-public'
-            s.license          = { :type => 'MIT', :file => 'LICENSE' }
+            s.license          = { :type => 'MIT' }
             s.author           = { '${{ steps.author_info.outputs.author_name }}' => '${{ steps.author_info.outputs.author_email }}' }
             s.source           = { :git => 'https://github.com/getzoop/zoop-package-public.git', :tag => '${{ github.event.release.tag_name }}' }
             s.source_files     = '${XCFRAMEWORK_ROOT}/**/*.h'


### PR DESCRIPTION
### **User description**
Corrige cocoapods


___

### **PR Type**
Bug fix


___

### **Description**
- Correção do caminho do framework no Cocoapods

- Remoção da referência ao arquivo de licença


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuração</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cocoa-pods.yml</strong><dd><code>Ajuste no caminho do framework e configuração de licença</code>&nbsp; </dd></summary>
<hr>

.github/workflows/cocoa-pods.yml

<li>Alteração do caminho do XCFRAMEWORK_ROOT de "./sources" para "sources"<br> <li> Remoção da referência ao arquivo 'LICENSE' na configuração de licença


</details>


  </td>
  <td><a href="https://github.com/getzoop/zoop-package-public/pull/11/files#diff-7249470b1169bbcc06e08b589ea756b192cf783bee6bcdb5defeab9acf3e5a8c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>